### PR TITLE
Fix issues not assigned to the specific repo codeowner

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -44,10 +44,13 @@ jobs:
     name: Assign Issue to the Primary CODEOWNER
     runs-on: ubuntu-latest
     if: ( 'issues' == github.event_name && ( 'opened' == github.event.action || 'reopened' == github.event.action ) && ( null == github.event.issue.assignee ) )
-    steps:      
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        
       - name: Check CODEOWNERS file existence
         id: codeowners_file_exists
-        uses: andstor/file-existence-action@v1
+        uses: andstor/file-existence-action@v2
         with:
           files: .github/CODEOWNERS
 


### PR DESCRIPTION
tested on the woocommerce integration repo:
https://github.com/gocodebox/lifterlms-integration-woocommerce/actions/runs/3426889768/jobs/5709222358

For some reason now the checkout on the repo is required.